### PR TITLE
Resolve joi validation error when injecting to hapi

### DIFF
--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -112,7 +112,7 @@ const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD'];
  * @param  {Object} req
  * @return {String|Undefined}
  */
-Handler.prototype.dispatch = function (req) {
+Handler.prototype.dispatch = function (req, callback) {
     // Make sure basic stuff is correct.
     if (methods.indexOf(req.method) === -1) return 'Invalid method.';
     if (typeof req.url !== 'string') return 'Invalid URL.';
@@ -129,7 +129,7 @@ Handler.prototype.dispatch = function (req) {
     }
 
     // At this point, we're good. Emit it!
-    this.emit('request', req);
+    this.emit('request', req, callback);
 };
 
 module.exports = Handler;

--- a/lib/handlers/sails.js
+++ b/lib/handlers/sails.js
@@ -53,7 +53,7 @@ SailsHandler.prototype.onRequest = function (ev, callback) {
         method: String(ev.method).toUpperCase(),
         url: ev.url,
         headers: ev.headers || {},
-        payload: ev.data || undefined
+        payload: ev.data || undefined,
     };
 
     const reqCallback = this.respond(callback || noop);

--- a/lib/handlers/sails.js
+++ b/lib/handlers/sails.js
@@ -53,11 +53,12 @@ SailsHandler.prototype.onRequest = function (ev, callback) {
         method: String(ev.method).toUpperCase(),
         url: ev.url,
         headers: ev.headers || {},
-        payload: ev.data || undefined,
-        callback: this.respond(callback || noop),
+        payload: ev.data || undefined
     };
 
-    const err = this.dispatch(request);
+    const reqCallback = this.respond(callback || noop);
+
+    const err = this.dispatch(request, reqCallback);
     if (err) request.callback(Boom.badRequest(err).output);
 };
 

--- a/lib/handlers/sails.js
+++ b/lib/handlers/sails.js
@@ -59,7 +59,7 @@ SailsHandler.prototype.onRequest = function (ev, callback) {
     const reqCallback = this.respond(callback || noop);
 
     const err = this.dispatch(request, reqCallback);
-    if (err) request.callback(Boom.badRequest(err).output);
+    if (err) reqCallback(Boom.badRequest(err).output);
 };
 
 /**

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -42,7 +42,7 @@ Manager.prototype.boot = function (registry) {
 
     // When the handler tells us we have a request, inject it into the
     // server and wait for the response.
-    this.handler.on('request', (req) => {
+    this.handler.on('request', (req, callback) => {
         req.headers['x-wsabi-manager'] = this.id;
         req.headers = lowerKeys(req.headers);
         this.syncCookies(req.headers);
@@ -54,7 +54,7 @@ Manager.prototype.boot = function (registry) {
             if (this.handler) {
                 this.updateCookies(lowerKeys(res.headers), 'set-cookie');
                 this.stripHeaders(res);
-                req.callback(res);
+                callback(res);
             }
         });
     });

--- a/test/handlers.test.js
+++ b/test/handlers.test.js
@@ -35,8 +35,8 @@ describe('sails handler', function () {
     });
 
     it('sends valid responses', function (done) {
-        handler.on('request', function (req) {
-            req.callback({ statusCode: 200, headers: { foo: 'bar' }, rawPayload: new Buffer('{"a":42}')});
+        handler.on('request', function (req, callback) {
+            callback({ statusCode: 200, headers: { foo: 'bar' }, rawPayload: new Buffer('{"a":42}')});
             done();
         });
         socket.emit('get', { method: 'get', headers: {}, data: {}, url: '/api/v1/users/current?' }, function (res) {
@@ -49,8 +49,8 @@ describe('sails handler', function () {
     });
 
     it('does not crash when no ACK callback', function (done) {
-        handler.on('request', function (req) {
-            req.callback({ statusCode: 200, headers: { foo: 'bar' }, rawPayload: new Buffer('{"a":42}')});
+        handler.on('request', function (req, callback) {
+            callback({ statusCode: 200, headers: { foo: 'bar' }, rawPayload: new Buffer('{"a":42}')});
             done();
         });
         socket.emit('get', { method: 'get', headers: {}, data: {}, url: '/api/v1/users/current?' });

--- a/test/manger.test.js
+++ b/test/manger.test.js
@@ -131,11 +131,12 @@ describe('manager', function () {
         });
 
         it('run requests', function () {
-            var req = { headers: { foo: 'bar' }, payload: {}, route: '/', callback: sinon.stub() };
+            var req = { headers: { foo: 'bar' }, payload: {}, route: '/' };
+            var callback = sinon.stub();
             sinon.stub(manager, 'syncCookies');
             sinon.stub(manager, 'updateCookies');
 
-            handler.emit('request', req);
+            handler.emit('request', req, callback);
             sinon.assert.calledWith(manager.syncCookies, req.headers);
             expect(req.headers['x-wsabi-manager']).to.equal(manager.id);
             sinon.assert.calledWith(manager.server.inject, req);
@@ -143,7 +144,7 @@ describe('manager', function () {
             var res = { headers: { 'set-cookie': 'asdf' }};
             manager.server.inject.yield(res);
             sinon.assert.calledWith(manager.updateCookies, res.headers);
-            sinon.assert.calledWith(req.callback, res);
+            sinon.assert.calledWith(callback, res);
         });
     });
 

--- a/test/manger.test.js
+++ b/test/manger.test.js
@@ -172,8 +172,9 @@ describe('manager', function () {
         });
 
         it('strips headers', function () {
-            var req = { headers: { foo: 'bar' }, payload: {}, route: '/', callback: sinon.stub() };
-            handler.emit('request', req);
+            var req = { headers: { foo: 'bar' }, payload: {}, route: '/' };
+            var callback = sinon.stub();
+            handler.emit('request', req, callback);
 
             var res = { headers: { 'silly': 'asdf' }};
             manager.server.inject.yield(res);


### PR DESCRIPTION
Newer versions of Hapi remove callback param from request when injecting, so Joi throws a validation error in runtime. 
